### PR TITLE
ti_k3: README: Add 'tifek' path

### DIFF
--- a/ti_k3/README
+++ b/ti_k3/README
@@ -5,4 +5,4 @@ key generation
 ./gen_keywr_cert.sh -g
 
 certificate creation
-./gen_keywr_cert.sh -s keys/phytecSMPK.pem --smek keys/phytecSMEK.key -b keys/phytecBMPK.pem --bmek keys/phytecBMEK.key -t ti_fek_public.pem -a keys/phytecAES256.key
+./gen_keywr_cert.sh -s keys/phytecSMPK.pem --smek keys/phytecSMEK.key -b keys/phytecBMPK.pem --bmek keys/phytecBMEK.key -t tifek/ti_fek_public.pem -a keys/phytecAES256.key


### PR DESCRIPTION
At least in OTP keywriter 11.01.00 that we refer to in our [Security Manual](https://phytec.github.io/doc-bsp-yocto/security/scarthgap-sec.html#installing-the-sdk), the TI fek public certificate is place in 'tifek' subfolder.